### PR TITLE
feat: replace timeago with dayjs

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -30,7 +30,6 @@
         "react-scripts": "5.0.1",
         "react-toastify": "^11.0.5",
         "socket.io-client": "^4.8.1",
-        "timeago.js": "^4.0.2",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       },
@@ -16425,12 +16424,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
-      "license": "MIT"
-    },
-    "node_modules/timeago.js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/timeago.js/-/timeago.js-4.0.2.tgz",
-      "integrity": "sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==",
       "license": "MIT"
     },
     "node_modules/tmpl": {

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "@types/react-dom": "^18.3.1",
     "axios": "^1.7.7",
     "classnames": "^2.5.1",
+    "dayjs": "^1.11.10",
     "dompurify": "^3.1.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -25,7 +26,6 @@
     "react-scripts": "5.0.1",
     "react-toastify": "^11.0.5",
     "socket.io-client": "^4.8.1",
-    "timeago.js": "^4.0.2",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/client/src/components/CommentThread.tsx
+++ b/client/src/components/CommentThread.tsx
@@ -1,6 +1,8 @@
 import React, { useRef, useState, useEffect } from "react";
 import { BsThreeDotsVertical } from "react-icons/bs";
-import { format } from "timeago.js";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+dayjs.extend(relativeTime);
 import ReplyInput from "./ReplyInput";
 import commentIcon from "../assets/commentsLight.png";
 
@@ -73,11 +75,11 @@ const CommentThread: React.FC<Props> = ({
   const canEditDelete = userId === comment.author._id || userRole === "admin";
 
   const displayTime = () => {
-    const createdTime = new Date(comment.createdAt).getTime() + timeDrift;
-    const currentTime = Date.now() + timeDrift;
+    const createdTime = dayjs(comment.createdAt).add(timeDrift, "millisecond");
+    const currentTime = dayjs().add(timeDrift, "millisecond");
 
-    if (Math.abs(currentTime - createdTime) < 10000) return "Just now";
-    return format(createdTime);
+    if (Math.abs(currentTime.diff(createdTime)) < 10000) return "Just now";
+    return createdTime.from(currentTime);
   };
 
   useEffect(() => {

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from "react";
 import axios from "axios";
 import { useNavigate, useLocation, Link } from "react-router-dom";
-import { format } from "timeago.js";
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+dayjs.extend(relativeTime);
 import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import clapSolidImage from "../assets/clapSolid.png";
@@ -155,7 +157,7 @@ const Home: React.FC = () => {
 
                   {/* DATE + CLAPS + COMMENTS */}
                   <div className="flex items-center gap-4 text-xs text-secondaryText">
-                    <span>{format(post.createdAt)}</span>
+                    <span>{dayjs(post.createdAt).fromNow()}</span>
                     <div className="flex items-center gap-4">
                       {hasClaps && (
                         <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- replace timeago.js usage with dayjs and relativeTime plugin
- remove timeago.js dependency and add dayjs

## Testing
- `npm test` (fails: Missing script: "test")
- `npm test -- --watchAll=false` (fails: Jest encountered an unexpected token)


------
https://chatgpt.com/codex/tasks/task_e_68b8b49811cc8328b270c2867e9f6d76